### PR TITLE
Add VSCode module to scaffolder

### DIFF
--- a/src/web/Ligare/web/scaffolding/__main__.py
+++ b/src/web/Ligare/web/scaffolding/__main__.py
@@ -25,7 +25,7 @@ class ScaffoldInputArgs(Namespace):
     name: Operation  # pyright: ignore[reportUninitializedInstanceVariable]
     endpoints: list[Operation] | None = None
     template_type: Literal["basic", "openapi"] = "basic"
-    modules: list[Literal["database", "test"]] | None = None
+    modules: list[str] | None = None
     output_directory: str | None = None
 
 
@@ -35,7 +35,7 @@ class ScaffoldParsedArgs(NamedTuple):
     name: Operation
     endpoints: list[Operation]
     template_type: Literal["basic", "openapi"]
-    modules: list[Literal["database", "test"]] | None
+    modules: list[str] | None
     output_directory: str
 
 
@@ -61,6 +61,14 @@ class ScaffolderCli:
         )
 
         self._log = logging.getLogger()
+
+    def _find_modules(self):
+        return [
+            module_path.name
+            for module_path in Path(
+                Path(__file__).parent.parent, Scaffolder.MODULE_TEMPLATE_DIRECTORY
+            ).iterdir()
+        ]
 
     def _parse_args(self, args: list[str]) -> ScaffoldParsedArgs:
         parser = ArgumentParser(description="Ligare Web Project Scaffolding Tool")
@@ -95,7 +103,7 @@ class ScaffolderCli:
             default="basic",
             help="The type of template to scaffold.",
         )
-        modules = ["database", "test"]
+        modules = self._find_modules()
         _ = create_parser.add_argument(
             "-m",
             choices=modules,

--- a/src/web/Ligare/web/scaffolding/scaffolder.py
+++ b/src/web/Ligare/web/scaffolding/scaffolder.py
@@ -76,6 +76,10 @@ class Scaffolder:
     _manager: Any
     _provider: IResourceProvider
 
+    MODULE_TEMPLATE_DIRECTORY = Path(
+        f"scaffolding/templates/optional/{{{{application.module_name}}}}/modules"
+    )
+
     def __init__(self, config: ScaffoldConfig, log: logging.Logger) -> None:
         self._config = config
         self._config_dict = asdict(config)
@@ -338,7 +342,7 @@ class Scaffolder:
             # module templates are stored under `optional/`
             # because we don't always want to render any given module.
             module_template_directory = Path(
-                f"scaffolding/templates/optional/{{{{application.module_name}}}}/modules/{module.module_name}"
+                Scaffolder.MODULE_TEMPLATE_DIRECTORY, module.module_name
             )
             # executed module hooks before any rendering is done
             # so the hooks can modify the config or do other

--- a/src/web/Ligare/web/scaffolding/templates/optional/{{application.module_name}}/modules/vscode/__meta__.j2
+++ b/src/web/Ligare/web/scaffolding/templates/optional/{{application.module_name}}/modules/vscode/__meta__.j2
@@ -1,0 +1,1 @@
+{{ render_module_template(".vscode/launch.json.j2", module_config, ".") }}

--- a/src/web/test/unit/scaffolding/test_scaffolding.py
+++ b/src/web/test/unit/scaffolding/test_scaffolding.py
@@ -405,7 +405,12 @@ def test__scaffold__uses_argv_when_sys_argv_not_set(mocker: MockerFixture):
 def test__scaffold__uses_argv_for_basic_scaffold_configuration(
     mode: str, config_name: str, config_value: str, mocker: MockerFixture
 ):
-    _ = mocker.patch("Ligare.web.scaffolding.__main__.Scaffolder")
+    from Ligare.web.scaffolding.scaffolder import Scaffolder
+
+    _ = mocker.patch(
+        "Ligare.web.scaffolding.__main__.Scaffolder",
+        MODULE_TEMPLATE_DIRECTORY=Scaffolder.MODULE_TEMPLATE_DIRECTORY,
+    )
     config_mock = mocker.patch("Ligare.web.scaffolding.__main__.ScaffoldConfig")
 
     argv_values = [mode, "-n", "test"]
@@ -429,7 +434,12 @@ def test__scaffold__uses_argv_for_endpoint_configuration(
     mode: str,
     mocker: MockerFixture,
 ):
-    _ = mocker.patch("Ligare.web.scaffolding.__main__.Scaffolder")
+    from Ligare.web.scaffolding.scaffolder import Scaffolder
+
+    _ = mocker.patch(
+        "Ligare.web.scaffolding.__main__.Scaffolder",
+        MODULE_TEMPLATE_DIRECTORY=Scaffolder.MODULE_TEMPLATE_DIRECTORY,
+    )
     config_mock = mocker.patch("Ligare.web.scaffolding.__main__.ScaffoldConfig")
 
     argv_values = [mode, "-n", "test", "-e", "foo", "-e", "bar"]
@@ -450,7 +460,12 @@ def test__scaffold__uses_argv_for_endpoint_configuration(
 def test__scaffold__create_mode_uses_argv_for_module_configuration(
     mocker: MockerFixture,
 ):
-    _ = mocker.patch("Ligare.web.scaffolding.__main__.Scaffolder")
+    from Ligare.web.scaffolding.scaffolder import Scaffolder
+
+    _ = mocker.patch(
+        "Ligare.web.scaffolding.__main__.Scaffolder",
+        MODULE_TEMPLATE_DIRECTORY=Scaffolder.MODULE_TEMPLATE_DIRECTORY,
+    )
     config_mock = mocker.patch("Ligare.web.scaffolding.__main__.ScaffoldConfig")
 
     argv_values = ["create", "-n", "test", "-m", "database"]


### PR DESCRIPTION
This PR adds a module to the scaffolder for users working with VSCode. Currently this just adds a launch.json with a couple debugger configurations.