### PR TITLE
Make feature flags easier to use and fix database errors

### DIFF
--- a/src/identity/pyproject.toml
+++ b/src/identity/pyproject.toml
@@ -28,6 +28,7 @@ classifiers = [
 ]
 
 dependencies = [
+    "injector",
     "pysaml2",
     "requests"
 ]

--- a/src/platform/Ligare/platform/feature_flag/__init__.py
+++ b/src/platform/Ligare/platform/feature_flag/__init__.py
@@ -2,6 +2,7 @@ from .caching_feature_flag_router import CachingFeatureFlagRouter
 from .caching_feature_flag_router import FeatureFlag as CacheFeatureFlag
 from .db_feature_flag_router import DBFeatureFlagRouter
 from .db_feature_flag_router import FeatureFlag as DBFeatureFlag
+from .decorators import feature_flag
 from .feature_flag_router import FeatureFlag, FeatureFlagChange, FeatureFlagRouter
 
 __all__ = (
@@ -12,4 +13,5 @@ __all__ = (
     "CacheFeatureFlag",
     "DBFeatureFlag",
     "FeatureFlagChange",
+    "feature_flag",
 )

--- a/src/platform/Ligare/platform/feature_flag/db_feature_flag_router.py
+++ b/src/platform/Ligare/platform/feature_flag/db_feature_flag_router.py
@@ -8,7 +8,6 @@ from sqlalchemy import Boolean, Column, String, Unicode
 from sqlalchemy.exc import NoResultFound
 from sqlalchemy.ext.declarative import DeclarativeMeta
 from sqlalchemy.orm.scoping import ScopedSession
-from sqlalchemy.orm.session import Session
 from typing_extensions import override
 
 from .caching_feature_flag_router import CachingFeatureFlagRouter
@@ -207,9 +206,9 @@ class DBFeatureFlagRouter(CachingFeatureFlagRouter[TFeatureFlag]):
 
         feature_flags = tuple(
             self._create_feature_flag(
-                name=cast(str, feature_flag.name),
-                enabled=cast(bool, feature_flag.enabled),
-                description=cast(str, feature_flag.description),
+                name=feature_flag.name,
+                enabled=feature_flag.enabled,
+                description=feature_flag.description,
             )
             for feature_flag in db_feature_flags
         )

--- a/src/platform/Ligare/platform/feature_flag/decorators.py
+++ b/src/platform/Ligare/platform/feature_flag/decorators.py
@@ -1,0 +1,40 @@
+from typing import Any, Callable
+
+from injector import Injector, inject
+from typing_extensions import overload
+
+from .feature_flag_router import FeatureFlag, FeatureFlagRouter
+
+
+@overload
+def feature_flag(
+    feature_flag_name: str, *, enabled_callback: Callable[..., Any]
+) -> Callable[..., Callable[..., Any]]: ...
+@overload
+def feature_flag(
+    feature_flag_name: str, *, disabled_callback: Callable[..., Any]
+) -> Callable[..., Callable[..., Any]]: ...
+
+
+def feature_flag(
+    feature_flag_name: str,
+    *,
+    enabled_callback: Callable[..., None] = lambda: None,
+    disabled_callback: Callable[..., None] = lambda: None,
+) -> Callable[..., Callable[..., Any]]:
+    def decorator(fn: Callable[..., Any]):
+        @inject
+        def wrapper(
+            feature_flag_router: FeatureFlagRouter[FeatureFlag],
+            injector: Injector,
+        ):
+            if feature_flag_router.feature_is_enabled(feature_flag_name):
+                enabled_callback()
+            else:
+                disabled_callback()
+
+            return injector.call_with_injection(fn)
+
+        return wrapper
+
+    return decorator

--- a/src/platform/pyproject.toml
+++ b/src/platform/pyproject.toml
@@ -28,7 +28,9 @@ classifiers = [
 ]
 
 dependencies = [
-    "Ligare.database"
+    "Ligare.database",
+
+    "injector"
 ]
 
 dynamic = ["version", "readme"]

--- a/src/web/Ligare/web/middleware/feature_flags/__init__.py
+++ b/src/web/Ligare/web/middleware/feature_flags/__init__.py
@@ -105,9 +105,6 @@ class DBFeatureFlagRouterModule:
         def _provide_db_feature_flag_router_table_base(
             self,
         ) -> type[FeatureFlagTableBase]:
-            # FeatureFlagTable is a FeatureFlagTableBase provided through
-            # SQLAlchemy's declarative meta API
-            # return cast(type[FeatureFlagTableBase], FeatureFlagTable)
             return self._feature_flag_table
 
     def __new__(

--- a/src/web/Ligare/web/middleware/feature_flags/__init__.py
+++ b/src/web/Ligare/web/middleware/feature_flags/__init__.py
@@ -74,7 +74,7 @@ class FeatureFlagRouterModule(ConfigurableModule, Generic[TFeatureFlag]):
     def _provide_feature_flag_router(
         self, injector: Injector
     ) -> FeatureFlagRouter[FeatureFlag]:
-        return injector.get(self._t_feature_flag)
+        return cast(FeatureFlagRouter[FeatureFlag], injector.get(self._t_feature_flag))
 
 
 class DBFeatureFlagRouterModule(FeatureFlagRouterModule[DBFeatureFlag]):
@@ -86,7 +86,9 @@ class DBFeatureFlagRouterModule(FeatureFlagRouterModule[DBFeatureFlag]):
     def _provide_db_feature_flag_router(
         self, injector: Injector
     ) -> FeatureFlagRouter[DBFeatureFlag]:
-        return injector.get(self._t_feature_flag)
+        return cast(
+            FeatureFlagRouter[DBFeatureFlag], injector.get(self._t_feature_flag)
+        )
 
     @singleton
     @provider
@@ -105,7 +107,9 @@ class CachingFeatureFlagRouterModule(FeatureFlagRouterModule[CachingFeatureFlag]
     def _provide_caching_feature_flag_router(
         self, injector: Injector
     ) -> FeatureFlagRouter[CachingFeatureFlag]:
-        return injector.get(self._t_feature_flag)
+        return cast(
+            FeatureFlagRouter[CachingFeatureFlag], injector.get(self._t_feature_flag)
+        )
 
 
 P = ParamSpec("P")

--- a/src/web/Ligare/web/scaffolding/templates/basic/{{application.module_name}}/config.toml.j2
+++ b/src/web/Ligare/web/scaffolding/templates/basic/{{application.module_name}}/config.toml.j2
@@ -8,7 +8,6 @@ sqlalchemy_echo = false
 app_name = '{{application.module_name}}'
 env = 'development'
 host = "localhost"
-# FIXME this should be an int
 port = "5000"
 
 [flask.session]
@@ -27,7 +26,7 @@ log_level = 'INFO'
 format = 'JSON'
 
 [web.security.cors]
-origins = ['http://localhost:5000']
+origins = ['http://localhost:5000', 'http://127.0.0.1:5000']
 allow_credentials = true
 allow_methods = ['GET', 'POST', 'PATCH', 'OPTIONS']
 

--- a/src/web/Ligare/web/scaffolding/templates/openapi/{{application.module_name}}/__main__.py.j2
+++ b/src/web/Ligare/web/scaffolding/templates/openapi/{{application.module_name}}/__main__.py.j2
@@ -1,5 +1,12 @@
+from Ligare.web.config import Config
+
 from {{application.module_name}} import create_app
 
-if __name__ == '__main__':
-    # TODO port must be taken from config
-    create_app().app_injector.app.run(port=5000)
+if __name__ == "__main__":
+    result = create_app()
+
+    app_config = result.app_injector.flask_injector.injector.get(Config)
+    host = app_config.flask and app_config.flask.host
+    port = 5000 if app_config.flask is None else int(app_config.flask.port)
+
+    result.app_injector.app.run(host=host, port=port)

--- a/src/web/Ligare/web/scaffolding/templates/openapi/{{application.module_name}}/config.toml.j2
+++ b/src/web/Ligare/web/scaffolding/templates/openapi/{{application.module_name}}/config.toml.j2
@@ -8,7 +8,6 @@ sqlalchemy_echo = false
 app_name = '{{application.module_name}}'
 env = 'development'
 host = "localhost"
-# FIXME this should be an int
 port = "5000"
 
 [flask.openapi]
@@ -34,7 +33,7 @@ log_level = 'INFO'
 format = 'plaintext'
 
 [web.security.cors]
-origins = ['http://localhost:5000']
+origins = ['http://localhost:5000', 'http://127.0.0.1:5000']
 allow_credentials = true
 allow_methods = ['GET', 'POST', 'PATCH', 'OPTIONS']
 

--- a/src/web/pyproject.toml
+++ b/src/web/pyproject.toml
@@ -41,6 +41,7 @@ dependencies = [
     "connexion[uvicorn]",
     "uvicorn-worker",
     "swagger_ui_bundle",
+    "injector",
     "python-dotenv",
     "json-logging",
     "lib_programname",

--- a/src/web/test/unit/middleware/test_feature_flags_middleware.py
+++ b/src/web/test/unit/middleware/test_feature_flags_middleware.py
@@ -94,8 +94,9 @@ class TestFeatureFlagsMiddleware(CreateOpenAPIApp):
                 bases=[],
             )
         )
-        application_modules.append(CachingFeatureFlagRouterModule)
-        application_modules.append(FeatureFlagMiddlewareModule())
+        application_modules.append(
+            FeatureFlagMiddlewareModule(CachingFeatureFlagRouterModule)
+        )
 
     def test__FeatureFlagMiddleware__feature_flag_api_GET_requires_user_session_when_flask_login_is_configured(
         self,
@@ -108,8 +109,9 @@ class TestFeatureFlagsMiddleware(CreateOpenAPIApp):
             application_configs: list[type[AbstractConfig]],
             application_modules: list[Module | type[Module]],
         ):
-            application_modules.append(CachingFeatureFlagRouterModule)
-            application_modules.append(FeatureFlagMiddlewareModule())
+            application_modules.append(
+                FeatureFlagMiddlewareModule(CachingFeatureFlagRouterModule)
+            )
 
         openapi_mock_controller.begin()
         app = next(
@@ -142,8 +144,9 @@ class TestFeatureFlagsMiddleware(CreateOpenAPIApp):
         ):
             if not flask_login_is_configured:
                 application_modules.clear()
-            application_modules.append(CachingFeatureFlagRouterModule)
-            application_modules.append(FeatureFlagMiddlewareModule())
+            application_modules.append(
+                FeatureFlagMiddlewareModule(CachingFeatureFlagRouterModule)
+            )
 
         def client_init_hook(app: CreateAppResult[FlaskApp]):
             caching_feature_flag_router = app.app_injector.flask_injector.injector.get(
@@ -363,8 +366,9 @@ class TestFeatureFlagsMiddleware(CreateOpenAPIApp):
         ):
             if not flask_login_is_configured:
                 application_modules.clear()
-            application_modules.append(CachingFeatureFlagRouterModule)
-            application_modules.append(FeatureFlagMiddlewareModule())
+            application_modules.append(
+                FeatureFlagMiddlewareModule(CachingFeatureFlagRouterModule)
+            )
 
         openapi_mock_controller.begin()
         app = next(


### PR DESCRIPTION
This PR:

* Adds a `feature_flag` decorator
* Fixes problems with the DBFeatureFlagRouter not functioning in `Ligare.web` application contexts