### PR TITLE
Simplify web application startup

### DIFF
--- a/src/programming/Ligare/programming/patterns/singleton.py
+++ b/src/programming/Ligare/programming/patterns/singleton.py
@@ -61,6 +61,7 @@ class Singleton(type):
         class Foo(metaclass=Singleton):
             _block_change = False
     """
+
     class InstanceValue:
         __value: Any
         __deleted: bool


### PR DESCRIPTION
This PR adds a method to expose the `uvicorn` and `Flask` `run` methods. This way, application authors don't need to futz around wit getting configuration information _and_ the applications will use the configuration options for host/port by default.

Targeting the `aholmes-add-documentation` branch because this is an enhancement coming from documentation updates.