### PR TITLE
Refactor ApplicationBuilder into `Ligare.programming`, removing it from `Ligare.web`

### DIFF
--- a/src/database/test/unit/migrations/alembic/test_env.py
+++ b/src/database/test/unit/migrations/alembic/test_env.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from unittest import mock
 
 import pytest
 from Ligare.database.migrations.alembic.env import run_migrations
@@ -25,7 +26,6 @@ def test__run_migrations__uses_specified_config_filename(mocker: MockerFixture):
     _ = mocker.patch(
         "Ligare.database.migrations.alembic.env.get_database_config_container"
     )
-    config_mock = mocker.patch("Ligare.database.migrations.alembic.env.Config")
     load_config_mock = mocker.patch(
         "Ligare.database.migrations.alembic.env.load_config"
     )
@@ -34,7 +34,7 @@ def test__run_migrations__uses_specified_config_filename(mocker: MockerFixture):
     config_filename = Path(get_random_str())
     run_migrations(MagicMock(), config_filename=config_filename)
 
-    load_config_mock.assert_called_once_with(config_mock, config_filename)
+    load_config_mock.assert_called_once_with(mock.ANY, config_filename)
 
 
 @pytest.mark.parametrize("mode", ["online", "offline"])

--- a/src/programming/Ligare/programming/application.py
+++ b/src/programming/Ligare/programming/application.py
@@ -1,0 +1,378 @@
+"""
+The framework API for creating applications.
+"""
+
+import logging
+from collections import defaultdict
+from dataclasses import dataclass
+from os import path
+from types import FunctionType
+from typing import (
+    Any,
+    Callable,
+    Generator,
+    Generic,
+    Protocol,
+    TypeVar,
+    cast,
+    final,
+    overload,
+)
+
+from injector import Binder, Injector, Module
+from lib_programname import get_path_executed_script
+from Ligare.AWS.ssm import SSMParameters
+from Ligare.programming.collections.dict import NestedDict
+from Ligare.programming.config import (
+    AbstractConfig,
+    ConfigBuilder,
+    TConfig,
+    load_config,
+)
+from Ligare.programming.config.exceptions import ConfigBuilderStateError
+from Ligare.programming.dependency_injection import ConfigModule
+from Ligare.programming.patterns.dependency_injection import (
+    BatchModule,
+    ConfigurableModule,
+    LoggerModule,
+)
+from Ligare.web.exception import BuilderBuildError, InvalidBuilderStateError
+from pydantic import BaseModel
+from typing_extensions import Self, override
+
+_get_program_dir = lambda: path.dirname(get_path_executed_script())
+_get_exec_dir = lambda: path.abspath(".")
+
+TApp = TypeVar("TApp")
+
+TAppConfig = TypeVar("TAppConfig", bound=AbstractConfig)
+
+
+class Config(BaseModel, AbstractConfig):
+    @override
+    def post_load(self) -> None:
+        return super().post_load()
+
+
+class AppModule(BatchModule, Generic[TApp]):
+    def __init__(
+        self,
+        exec: type[TApp] | Callable[..., TApp] | None = None,
+        app_name: str | None = None,
+        *args: tuple[Any, Any],
+    ) -> None:
+        super().__init__(dict({(arg[0], arg[1]) for arg in args}))
+
+        if exec is None:
+            self._name = app_name if app_name else "app"
+            self._exec = None
+        else:
+            if getattr(exec, "__module__", None) == "builtins":
+                raise Exception(
+                    "App module type cannot be a builtin like `type`, `object`, etc. It must be a `type[TApp]`."
+                )
+            self._name = app_name if app_name else exec.__name__
+            self._exec = exec
+
+    @override
+    def configure(self, binder: Binder) -> None:
+        super().configure(binder)
+
+        if self._exec is not None:
+            if isinstance(self._exec, type) and not self._exec == type:
+                binder.bind(self._exec, to=self._exec())
+            else:
+                if isinstance(self._exec, FunctionType):
+                    to: TApp = self._exec()
+                    binder.bind(type(to), to=to)
+                else:
+                    binder.bind(type(self._exec), to=self._exec)
+
+        binder.install(LoggerModule(self._name))
+
+
+@dataclass
+class AppInjector(Generic[TApp]):
+    """
+    Contains an instantiated `TApp` application in `app`,
+    and its associated `Injector` IoC container.
+
+    :param TApp Generic: An instance of the app.
+    :param inject Injector: The applications IoC container.
+    """
+
+    app: TApp
+    injector: Injector
+
+
+@dataclass
+class CreateAppResult(Generic[TApp]):
+    """
+    TODO update this
+    Contains an instantiated Flask application and its
+    associated application "container." This is either
+    the same Flask instance, or an OpenAPI application.
+
+    :param flask_app Generic: The Flask application.
+    :param app_injector AppInjector[TApp]: The application's wrapper and IoC container.
+    """
+
+    app_injector: AppInjector[TApp]
+
+
+class UseConfigurationCallback(Protocol[TConfig]):
+    """
+    The callback for configuring an application's configuration.
+
+    :param TConfig Protocol: The AbstractConfig type to be configured.
+    """
+
+    def __call__(
+        self,
+        config_builder: ConfigBuilder[TConfig],
+        config_overrides: dict[str, Any],
+    ) -> "None | ConfigBuilder[TConfig]":
+        """
+        Set up parameters for the application's configuration.
+
+        :param ConfigBuilder[TConfig] config_builder: The ConfigBuilder instance.
+        :param dict[str, Any] config_overrides: A dictionary of key/values that are applied over all keys that might exist in an instantiated config.
+        :raises InvalidBuilderStateError: Upon a call to `build()`, the builder is misconfigured.
+        :raises BuilderBuildError: Upon a call to `build()`, a failure occurred during the instantiation of the configuration.
+        :raises Exception: Upon a call to `build()`, an unknown error occurred.
+        :return None | ConfigBuilder[TConfig]: The callback may return `None` or the received `ConfigBuilder` instance so as to support the use of lambdas. This return value is not used.
+        """
+
+
+@final
+class ApplicationConfigBuilder(Generic[TConfig]):
+    _DEFAULT_CONFIG_FILENAME: str = "config.toml"
+
+    def __init__(self) -> None:
+        self._config_value_overrides: dict[str, Any] = {}
+        self._config_builder: ConfigBuilder[TConfig] = ConfigBuilder[TConfig]()
+        self._config_filename: str = ApplicationConfigBuilder._DEFAULT_CONFIG_FILENAME
+        self._use_filename: bool = False
+        self._use_ssm: bool = False
+
+    def with_config_builder(self, config_builder: ConfigBuilder[TConfig]) -> Self:
+        self._config_builder = config_builder
+        return self
+
+    def with_root_config_type(self, config_type: type[TConfig]) -> Self:
+        _ = self._config_builder.with_root_config(config_type)
+        return self
+
+    def with_config_types(self, configs: list[type[AbstractConfig]] | None) -> Self:
+        _ = self._config_builder.with_configs(configs)
+        return self
+
+    def with_config_type(self, config_type: type[AbstractConfig]) -> Self:
+        _ = self._config_builder.with_config(config_type)
+        return self
+
+    def with_config_value_overrides(self, values: dict[str, Any]) -> Self:
+        self._config_value_overrides = values
+        return self
+
+    def with_config_filename(self, filename: str) -> Self:
+        self._config_filename = filename
+        self._use_filename = True
+        return self
+
+    def enable_ssm(self, value: bool) -> Self:
+        """
+        Try to load config from AWS SSM. If `use_filename` was configured,
+        a failed attempt to load from SSM will instead attempt to load from
+        the configured filename. If `use_filename` is not configured and SSM
+        fails, an exception is raised. If SSM succeeds, `build` will not
+        load from the configured filename.
+
+        :param bool value: Whether to use SSM
+        :return Self:
+        """
+        self._use_ssm = value
+        return self
+
+    def build(self) -> TConfig | None:
+        if not (self._use_ssm or self._use_filename):
+            raise InvalidBuilderStateError(
+                f"Cannot build the application config without either `{ApplicationConfigBuilder[TConfig].enable_ssm.__name__}` or `{ApplicationConfigBuilder[TConfig].with_config_filename.__name__}` having been configured."
+            )
+
+        try:
+            config_type = self._config_builder.build()
+        except ConfigBuilderStateError as e:
+            raise BuilderBuildError(
+                f"A root config must be specified using `{ApplicationConfigBuilder[TConfig].with_root_config_type.__name__}`, `{ApplicationConfigBuilder[TConfig].with_config_type.__name__}`, or `{ApplicationConfigBuilder[TConfig].with_config_types.__name__}` before calling `{ApplicationConfigBuilder[TConfig].build.__name__}`."
+            ) from e
+
+        full_config: TConfig | None = None
+        SSM_FAIL_ERROR_MSG = "Unable to load configuration. SSM parameter load failed and the builder is configured not to load from a file."
+        if self._use_ssm:
+            try:
+                # requires that aws-ssm.ini exists and is correctly configured
+                ssm_parameters = SSMParameters()
+                full_config = ssm_parameters.load_config(config_type)
+
+                if not self._use_filename and full_config is None:
+                    raise BuilderBuildError(SSM_FAIL_ERROR_MSG)
+            except Exception as e:
+                if self._use_filename:
+                    logging.getLogger().info("SSM parameter load failed.", exc_info=e)
+                else:
+                    raise BuilderBuildError(SSM_FAIL_ERROR_MSG) from e
+
+        if self._use_filename and full_config is None:
+            if self._config_value_overrides:
+                full_config = load_config(
+                    config_type, self._config_filename, self._config_value_overrides
+                )
+            else:
+                full_config = load_config(config_type, self._config_filename)
+
+        return full_config
+
+
+class ApplicationConfigBuilderCallback(Protocol[TAppConfig]):
+    def __call__(
+        self,
+        config_builder: ApplicationConfigBuilder[TAppConfig],
+    ) -> "None | ApplicationConfigBuilder[TAppConfig]": ...
+
+
+@final
+class ApplicationBuilder(Generic[TApp]):
+    def __init__(self, exec: type[TApp] | Callable[..., TApp]) -> None:
+        self._modules: list[Module | type[Module]] = [AppModule(exec)]
+        self._config_overrides: dict[str, Any] = {}
+
+    _APPLICATION_CONFIG_BUILDER_PROPERTY_NAME: str = "__application_config_builder"
+
+    @property
+    def _application_config_builder(self) -> ApplicationConfigBuilder[AbstractConfig]:
+        builder = getattr(
+            self, ApplicationBuilder._APPLICATION_CONFIG_BUILDER_PROPERTY_NAME, None
+        )
+
+        if builder is None:
+            builder = ApplicationConfigBuilder[AbstractConfig]()
+            self._application_config_builder = builder.with_root_config_type(Config)
+
+        return builder
+
+    @_application_config_builder.setter
+    def _application_config_builder(
+        self, value: ApplicationConfigBuilder[AbstractConfig]
+    ):
+        setattr(
+            self, ApplicationBuilder._APPLICATION_CONFIG_BUILDER_PROPERTY_NAME, value
+        )
+
+    @overload
+    def with_module(self, module: Module) -> Self: ...
+    @overload
+    def with_module(self, module: type[Module]) -> Self: ...
+    def with_module(self, module: Module | type[Module]) -> Self:
+        module_type = type(module) if isinstance(module, Module) else module
+        if issubclass(module_type, ConfigurableModule):
+            _ = self._application_config_builder.with_config_type(
+                module_type.get_config_type()
+            )
+
+        self._modules.append(module)
+        return self
+
+    def with_modules(self, modules: list[Module | type[Module]] | None) -> Self:
+        if modules is not None:
+            for module in modules:
+                _ = self.with_module(module)
+        return self
+
+    @overload
+    def use_configuration(
+        self,
+        __application_config_builder_callback: ApplicationConfigBuilderCallback[
+            AbstractConfig
+        ],
+    ) -> Self:
+        """
+        Execute changes to the builder's `ApplicationConfigBuilder[TAppConfig]` instance.
+
+        `__builder_callback` can return `None`, or the instance of `ApplicationConfigBuilder[TAppConfig]` passed to its `config_builder` argument.
+        This allowance is so lambdas can be used; `ApplicationBuilder[T_app, TAppConfig]` does not use the return value.
+        """
+        ...
+
+    @overload
+    def use_configuration(
+        self, __application_config_builder: ApplicationConfigBuilder[AbstractConfig]
+    ) -> Self:
+        """Replace the builder's default `ApplicationConfigBuilder[TAppConfig]` instance, or any instance previously assigned."""
+        ...
+
+    def use_configuration(
+        self,
+        application_config_builder: ApplicationConfigBuilderCallback[AbstractConfig]
+        | ApplicationConfigBuilder[AbstractConfig],
+    ) -> Self:
+        if callable(application_config_builder):
+            _ = application_config_builder(self._application_config_builder)
+        else:
+            self._application_config_builder = application_config_builder
+
+        return self
+
+    # FIXME this method actually only returns an injector, so perhaps the class should be renamed.
+    def build(self) -> Injector:  # CreateAppResult[TApp]:
+        config_overrides: NestedDict[str, Any] = defaultdict(dict)
+
+        _ = self._application_config_builder.with_config_value_overrides(
+            config_overrides
+        )
+        try:
+            config = self._application_config_builder.build()
+        except InvalidBuilderStateError as e:
+            raise BuilderBuildError(
+                f"`{ApplicationBuilder[TApp].__name__}` failed to build the application configuration because the `{ApplicationConfigBuilder[AbstractConfig].__name__}` instance was improperly configured. \
+Review the exception raised from `{ApplicationConfigBuilder[AbstractConfig].__name__}` and apply fixes through this `{ApplicationBuilder[TApp].__name__}` instance's `{ApplicationBuilder[TApp].use_configuration.__name__}` method."
+            ) from e
+        except BuilderBuildError as e:
+            raise BuilderBuildError(
+                f"`{ApplicationBuilder[TApp].__name__}` failed to build the application configuration due to an error when creating the application configuration. \
+Review the exception raised from `{ApplicationConfigBuilder[AbstractConfig].__name__}` and apply fixes through this `{ApplicationBuilder[TApp].__name__}` instance's `{ApplicationBuilder[TApp].use_configuration.__name__}` method."
+            ) from e
+
+        if config is None:
+            raise BuilderBuildError(
+                f"The application configuration failed to load for an unknown reason. Review the `{ApplicationConfigBuilder[AbstractConfig].__name__}` instance's configuration."
+            )
+
+        app: TApp
+
+        application_modules = [
+            ConfigModule(config, type(config))
+            for (_, config) in cast(
+                Generator[tuple[str, AbstractConfig], None, None], config
+            )
+        ] + (self._modules if self._modules else [])
+        # The `config` module cannot be overridden unless the application
+        # IoC container is fiddled with. `config` is the instance registered
+        # to `AbstractConfig`.
+        modules = (
+            [ConfigModule(config, Config)]
+            + [
+                (module if isinstance(module, Module) else module())
+                for module in (application_modules if application_modules else [])
+            ]
+            # + [
+            #    (module if isinstance(module, Module) else module())
+            #    for module in [AppModule(app)]
+            #    + (application_modules if application_modules else [])
+            # ]
+        )
+        injector = Injector(modules)
+        # flask_injector.injector.binder.bind(Injector, flask_injector.injector)
+
+        # return CreateAppResult[TApp](app, AppInjector[TApp](app, injector))
+        return injector

--- a/src/programming/Ligare/programming/application.py
+++ b/src/programming/Ligare/programming/application.py
@@ -51,7 +51,9 @@ class ApplicationBaseProtocol(Protocol):
         pass
 
 
-TApp = TypeVar("TApp", bound=ApplicationBaseProtocol)
+TApp = TypeVar(
+    "TApp", bound=ApplicationBaseProtocol, covariant=True, contravariant=False
+)
 
 
 class AppModule(BatchModule, Generic[TApp]):
@@ -99,6 +101,16 @@ class AppModule(BatchModule, Generic[TApp]):
         binder.install(LoggerModule(self._name))
 
 
+class CreateAppResultProtocol(Protocol[TApp]):
+    @property
+    def app(self) -> TApp: ...
+
+    @property
+    def injector(self) -> Injector: ...
+
+    def run(self) -> None: ...
+
+
 @dataclass
 class CreateAppResult(Generic[TApp]):
     """
@@ -112,7 +124,7 @@ class CreateAppResult(Generic[TApp]):
     app: TApp
     injector: Injector
 
-    def run(self):
+    def run(self) -> None:
         return self.injector.call_with_injection(self.app.run)
 
 
@@ -378,7 +390,7 @@ Review the exception raised from `{ApplicationConfigBuilder[AbstractConfig].__na
             for module in (application_modules if application_modules else [])
         ]
 
-    def build(self) -> CreateAppResult[TApp]:
+    def build(self) -> CreateAppResultProtocol[TApp]:
         config = self._build_config()
 
         self._register_config_modules(config)

--- a/src/programming/Ligare/programming/application.py
+++ b/src/programming/Ligare/programming/application.py
@@ -4,7 +4,6 @@ The framework API for creating applications.
 
 import abc
 import logging
-from collections import defaultdict
 from dataclasses import dataclass
 from types import FunctionType
 from typing import (
@@ -21,7 +20,6 @@ from typing import (
 
 from injector import Binder, Injector, Module
 from Ligare.AWS.ssm import SSMParameters
-from Ligare.programming.collections.dict import NestedDict
 from Ligare.programming.config import (
     AbstractConfig,
     Config,
@@ -48,7 +46,12 @@ class ApplicationBase(abc.ABC):
         pass
 
 
-TApp = TypeVar("TApp", bound=ApplicationBase)
+class ApplicationBaseProtocol(Protocol):
+    def run(self, *args: Any, **kwargs: Any):
+        pass
+
+
+TApp = TypeVar("TApp", bound=ApplicationBaseProtocol)
 
 
 class AppModule(BatchModule, Generic[TApp]):

--- a/src/programming/Ligare/programming/config/__init__.py
+++ b/src/programming/Ligare/programming/config/__init__.py
@@ -14,7 +14,8 @@ from Ligare.programming.config.exceptions import (
     ConfigInvalidError,
     NotEndsWithConfigError,
 )
-from typing_extensions import Self
+from pydantic import BaseModel
+from typing_extensions import Self, override
 
 
 class AbstractConfig(abc.ABC):
@@ -27,6 +28,12 @@ class AbstractConfig(abc.ABC):
         """
         This method is called by `load_config` after TOML data has been loaded into the pluggable config type instance.
         """
+
+
+class Config(BaseModel, AbstractConfig):
+    @override
+    def post_load(self) -> None:
+        return super().post_load()
 
 
 TConfig = TypeVar("TConfig", bound=AbstractConfig)

--- a/src/programming/Ligare/programming/config/__init__.py
+++ b/src/programming/Ligare/programming/config/__init__.py
@@ -97,7 +97,10 @@ class ConfigBuilder(Generic[TConfig]):
         :return type[TConfig]: The TConfig type, including any pluggable config types
         """
         if self._root_config and not self._configs:
-            return self._root_config
+            _new_type = cast(
+                "type[TConfig]", type("GeneratedConfig", (self._root_config,), {})
+            )
+            return _new_type
 
         if not self._configs:
             raise ConfigBuilderStateError(
@@ -155,8 +158,10 @@ def load_config(
         config_dict: dict[str, Any] = toml.load(toml_file_path)
     except FileNotFoundError as e:
         full_path = Path(toml_file_path).resolve()
-        raise ConfigInvalidError(f"The configuration file specified, `{toml_file_path}`, could not be found at `{full_path}` and was not loaded. \
-Is the file path correct?") from e
+        raise ConfigInvalidError(
+            f"The configuration file specified, `{toml_file_path}`, could not be found at `{full_path}` and was not loaded. \
+Is the file path correct?"
+        ) from e
 
     if config_overrides is not None:
         config_dict = merge(config_dict, config_overrides)

--- a/src/programming/test/unit/test_config.py
+++ b/src/programming/test/unit/test_config.py
@@ -101,8 +101,18 @@ def test__ConfigBuilder__build__uses_root_config_when_no_section_configs_specifi
     config_builder = ConfigBuilder[TestConfig]()
     _ = config_builder.with_root_config(TestConfig)
     config_type = config_builder.build()
-    assert config_type is TestConfig
+    assert issubclass(config_type, TestConfig)
     assert isinstance(config_type(), TestConfig)
+
+
+def test__ConfigBuilder__build__config_instance_base_class_is_the_specified_root_config_type_when_no_section_configs_specified():
+    config_builder = ConfigBuilder[TestConfig]()
+    _ = config_builder.with_root_config(TestConfig)
+    config_type = config_builder.build()
+    assert issubclass(config_type, TestConfig)
+    assert isinstance(config_type(), TestConfig)
+    assert config_type.__bases__[0] is TestConfig
+    assert config_type().__class__.__bases__[0] is TestConfig
 
 
 def test__ConfigBuilder__build__creates_config_type_when_multiple_configs_specified(
@@ -120,6 +130,17 @@ def test__ConfigBuilder__build__creates_config_type_when_multiple_configs_specif
 
     assert TestConfig in config_type.__mro__
     assert hasattr(config, "baz")
+
+
+def test__ConfigBuilder__build__config_instance_base_class_is_the_specified_root_config_type_when_multiple_configs_specified():
+    config_builder = ConfigBuilder[TestConfig]()
+    _ = config_builder.with_root_config(TestConfig)
+    _ = config_builder.with_configs([BazConfig])
+    config_type = config_builder.build()
+    assert issubclass(config_type, TestConfig)
+    assert isinstance(config_type(), TestConfig)
+    assert config_type.__bases__[0] is TestConfig
+    assert config_type().__class__.__bases__[0] is TestConfig
 
 
 def test__ConfigBuilder__build__sets_dynamic_config_values_when_multiple_configs_specified(

--- a/src/web/Ligare/web/application.py
+++ b/src/web/Ligare/web/application.py
@@ -23,6 +23,7 @@ from connexion import FlaskApp
 from connexion.options import SwaggerUIOptions
 from flask import Blueprint, Flask
 from flask_injector import FlaskInjector
+from injector import Injector
 from lib_programname import get_path_executed_script
 from Ligare.AWS.ssm import SSMParameters
 from Ligare.programming.application import ApplicationBase
@@ -88,6 +89,17 @@ class CreateAppResult(ApplicationBase, Generic[T_app]):
 
     flask_app: Flask
     app_injector: AppInjector[T_app]
+
+    @property
+    def app(self) -> T_app:
+        return self.app_injector.app
+
+    @property
+    def injector(self) -> Injector:
+        return self.app_injector.flask_injector.injector
+
+    @overload
+    def run(self) -> None: ...
 
     @overload
     def run(

--- a/src/web/Ligare/web/application.py
+++ b/src/web/Ligare/web/application.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from os import environ, path
 from typing import (
     Any,
+    Callable,
     Generator,
     Generic,
     Optional,
@@ -26,6 +27,8 @@ from flask_injector import FlaskInjector
 from injector import Module
 from lib_programname import get_path_executed_script
 from Ligare.AWS.ssm import SSMParameters
+from Ligare.programming.application import ApplicationBase
+from Ligare.programming.application import ApplicationBuilder as AppBuild
 from Ligare.programming.collections.dict import NestedDict
 from Ligare.programming.config import (
     AbstractConfig,
@@ -40,7 +43,7 @@ from Ligare.programming.config.exceptions import (
 from Ligare.programming.dependency_injection import ConfigModule
 from Ligare.programming.patterns.dependency_injection import ConfigurableModule
 from Ligare.web.exception import BuilderBuildError, InvalidBuilderStateError
-from typing_extensions import Self
+from typing_extensions import Self, override
 
 from .config import Config, FlaskConfig
 from .middleware import (
@@ -75,7 +78,7 @@ class AppInjector(Generic[T_app]):
 
 
 @dataclass
-class CreateAppResult(Generic[T_app]):
+class CreateAppResult(ApplicationBase, Generic[T_app]):
     """
     Contains an instantiated Flask application and its
     associated application "container." This is either
@@ -88,8 +91,63 @@ class CreateAppResult(Generic[T_app]):
     flask_app: Flask
     app_injector: AppInjector[T_app]
 
+    @overload
+    def run(
+        self: "CreateAppResult[Flask]",
+        *,
+        host: str | None = None,
+        port: int | None = None,
+        debug: bool | None = None,
+        load_dotenv: bool = True,
+        **options: Any,
+    ) -> None:
+        """
+        Call this method to start your application.
+        This method is a passthrough for `Flask.run`.
+
+        Reference https://github.com/encode/uvicorn/blob/fe3910083e3990695bc19c2ef671dd447262ae18/uvicorn/main.py#L463
+
+        :param host: The hostname this application should accept requests for.
+                              If `None`, the value in the application's `FlaskConfig` instance is used;
+                              otherwise, this parameter value is used.
+        :param port: The port this application should listen on for requests.
+                              If `None`, the value in the application's `FlaskConfig` instance is used;
+                              otherwise, this parameter value is used.
+        """
+        ...
+
+    @overload
+    def run(
+        self: "CreateAppResult[FlaskApp]",
+        *,
+        import_string: str | None = None,
+        host: str | None = None,
+        # uvicorn's default is 8000 but we default to 5000
+        # and try to load the value from a config file
+        port: int | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """
+        Call this method to start your application.
+        This method is partly a passthrough for `uvicorn.run`.
+
+        Reference https://github.com/encode/uvicorn/blob/fe3910083e3990695bc19c2ef671dd447262ae18/uvicorn/main.py#L463
+
+        :param import_string: application as import string (eg. "main:app"). This is needed to run
+                              using reload.
+        :param host: The hostname this application should accept requests for.
+                              If `None`, the value in the application's `FlaskConfig` instance is used;
+                              otherwise, this parameter value is used.
+        :param port: The port this application should listen on for requests.
+                              If `None`, the value in the application's `FlaskConfig` instance is used;
+                              otherwise, this parameter value is used.
+        """
+        ...
+
+    @override
     def run(
         self,
+        *,
         import_string: str | None = None,
         # uvicorn's default is 127.0.0.1 but we default to localhost
         # and try to load the value from a config file
@@ -262,82 +320,14 @@ class ApplicationConfigBuilderCallback(Protocol[TAppConfig]):
 
 
 @final
-class ApplicationBuilder(Generic[T_app]):
-    def __init__(self) -> None:
-        self._modules: list[Module | type[Module]] = []
-        self._config_overrides: dict[str, Any] = {}
-
-    _APPLICATION_CONFIG_BUILDER_PROPERTY_NAME: str = "__application_config_builder"
-
-    @property
-    def _application_config_builder(self) -> ApplicationConfigBuilder[Config]:
-        builder = getattr(
-            self, ApplicationBuilder._APPLICATION_CONFIG_BUILDER_PROPERTY_NAME, None
-        )
-
-        if builder is None:
-            builder = ApplicationConfigBuilder[Config]()
-            self._application_config_builder = builder.with_root_config_type(Config)
-
-        return builder
-
-    @_application_config_builder.setter
-    def _application_config_builder(self, value: ApplicationConfigBuilder[Config]):
-        setattr(
-            self, ApplicationBuilder._APPLICATION_CONFIG_BUILDER_PROPERTY_NAME, value
-        )
-
-    @overload
-    def with_module(self, module: Module) -> Self: ...
-    @overload
-    def with_module(self, module: type[Module]) -> Self: ...
-    def with_module(self, module: Module | type[Module]) -> Self:
-        module_type = type(module) if isinstance(module, Module) else module
-        if issubclass(module_type, ConfigurableModule):
-            _ = self._application_config_builder.with_config_type(
-                module_type.get_config_type()
-            )
-
-        self._modules.append(module)
-        return self
-
-    def with_modules(self, modules: list[Module | type[Module]] | None) -> Self:
-        if modules is not None:
-            for module in modules:
-                _ = self.with_module(module)
-        return self
-
-    @overload
-    def use_configuration(
+class ApplicationBuilder(AppBuild[T_app]):
+    def __init__(
         self,
-        __application_config_builder_callback: ApplicationConfigBuilderCallback[Config],
-    ) -> Self:
-        """
-        Execute changes to the builder's `ApplicationConfigBuilder[TAppConfig]` instance.
-
-        `__builder_callback` can return `None`, or the instance of `ApplicationConfigBuilder[TAppConfig]` passed to its `config_builder` argument.
-        This allowance is so lambdas can be used; `ApplicationBuilder[T_app, TAppConfig]` does not use the return value.
-        """
-        ...
-
-    @overload
-    def use_configuration(
-        self, __application_config_builder: ApplicationConfigBuilder[Config]
-    ) -> Self:
-        """Replace the builder's default `ApplicationConfigBuilder[TAppConfig]` instance, or any instance previously assigned."""
-        ...
-
-    def use_configuration(
-        self,
-        application_config_builder: ApplicationConfigBuilderCallback[Config]
-        | ApplicationConfigBuilder[Config],
-    ) -> Self:
-        if callable(application_config_builder):
-            _ = application_config_builder(self._application_config_builder)
-        else:
-            self._application_config_builder = application_config_builder
-
-        return self
+        exec: type[T_app] | Callable[..., T_app],
+        import_name: str,
+        **kwargs: dict[str, Any],
+    ) -> None:
+        super().__init__(exec=exec, import_name=import_name, **kwargs)
 
     def with_flask_app_name(self, value: str | None) -> Self:
         self._config_overrides["app_name"] = value
@@ -347,6 +337,7 @@ class ApplicationBuilder(Generic[T_app]):
         self._config_overrides["env"] = value
         return self
 
+    @override
     def build(self) -> CreateAppResult[T_app]:
         config_overrides: NestedDict[str, Any] = defaultdict(dict)
 
@@ -363,23 +354,9 @@ class ApplicationBuilder(Generic[T_app]):
         _ = self._application_config_builder.with_config_value_overrides(
             config_overrides
         )
-        try:
-            config = self._application_config_builder.build()
-        except InvalidBuilderStateError as e:
-            raise BuilderBuildError(
-                f"`{ApplicationBuilder[T_app].__name__}` failed to build the application configuration because the `{ApplicationConfigBuilder[Config].__name__}` instance was improperly configured. \
-Review the exception raised from `{ApplicationConfigBuilder[Config].__name__}` and apply fixes through this `{ApplicationBuilder[T_app].__name__}` instance's `{ApplicationBuilder[T_app].use_configuration.__name__}` method."
-            ) from e
-        except BuilderBuildError as e:
-            raise BuilderBuildError(
-                f"`{ApplicationBuilder[T_app].__name__}` failed to build the application configuration due to an error when creating the application configuration. \
-Review the exception raised from `{ApplicationConfigBuilder[Config].__name__}` and apply fixes through this `{ApplicationBuilder[T_app].__name__}` instance's `{ApplicationBuilder[T_app].use_configuration.__name__}` method."
-            ) from e
 
-        if config is None:
-            raise BuilderBuildError(
-                f"The application configuration failed to load for an unknown reason. Review the `{ApplicationConfigBuilder[Config].__name__}` instance's configuration."
-            )
+        config = cast(Config, self._build_config())
+        self._register_config_modules(config)
 
         if config.flask is None:
             raise ConfigInvalidError(
@@ -390,8 +367,6 @@ Review the exception raised from `{ApplicationConfigBuilder[Config].__name__}` a
             raise ConfigInvalidError(
                 "You must set the Flask application name in the [flask.app_name] config or FLASK_APP envvar. Review the documentation for the Ligare.web TOML format and requirements."
             )
-
-        app: T_app
 
         if config.flask.openapi is not None:
             openapi = configure_openapi(config)
@@ -404,16 +379,8 @@ Review the exception raised from `{ApplicationConfigBuilder[Config].__name__}` a
         _ = register_api_response_handlers(app)
         _ = register_context_middleware(app)
 
-        application_modules = [
-            ConfigModule(config, type(config))
-            for (_, config) in cast(
-                Generator[tuple[str, AbstractConfig], None, None], config
-            )
-        ] + (self._modules if self._modules else [])
-        # The `config` module cannot be overridden unless the application
-        # IoC container is fiddled with. `config` is the instance registered
-        # to `AbstractConfig`.
-        modules = application_modules + [ConfigModule(config, Config)]
+        modules = self._build_application_modules()
+
         flask_injector = configure_dependencies(app, application_modules=modules)
 
         flask_app = app.app if isinstance(app, FlaskApp) else app

--- a/src/web/Ligare/web/application.py
+++ b/src/web/Ligare/web/application.py
@@ -9,7 +9,6 @@ from os import environ, path
 from typing import (
     Any,
     Callable,
-    Generator,
     Generic,
     Optional,
     Protocol,
@@ -24,11 +23,12 @@ from connexion import FlaskApp
 from connexion.options import SwaggerUIOptions
 from flask import Blueprint, Flask
 from flask_injector import FlaskInjector
-from injector import Module
 from lib_programname import get_path_executed_script
 from Ligare.AWS.ssm import SSMParameters
 from Ligare.programming.application import ApplicationBase
-from Ligare.programming.application import ApplicationBuilder as AppBuild
+from Ligare.programming.application import (
+    ApplicationBuilder as GenericApplicationBuilder,
+)
 from Ligare.programming.collections.dict import NestedDict
 from Ligare.programming.config import (
     AbstractConfig,
@@ -40,8 +40,6 @@ from Ligare.programming.config.exceptions import (
     ConfigBuilderStateError,
     ConfigInvalidError,
 )
-from Ligare.programming.dependency_injection import ConfigModule
-from Ligare.programming.patterns.dependency_injection import ConfigurableModule
 from Ligare.web.exception import BuilderBuildError, InvalidBuilderStateError
 from typing_extensions import Self, override
 
@@ -320,7 +318,7 @@ class ApplicationConfigBuilderCallback(Protocol[TAppConfig]):
 
 
 @final
-class ApplicationBuilder(AppBuild[T_app]):
+class ApplicationBuilder(GenericApplicationBuilder[T_app]):
     def __init__(
         self,
         exec: type[T_app] | Callable[..., T_app],

--- a/src/web/test/unit/application/test_create_flask_app.py
+++ b/src/web/test/unit/application/test_create_flask_app.py
@@ -1,14 +1,10 @@
 import pathlib
-from os import environ
 from pathlib import Path
 from typing import cast
 
 import pytest
-from flask import Blueprint, Flask
-from Ligare.programming.config import AbstractConfig
+from flask import Blueprint
 from Ligare.programming.config.exceptions import ConfigInvalidError
-from Ligare.programming.str import get_random_str
-from Ligare.web.application import App  # pyright: ignore[reportDeprecated]
 from Ligare.web.application import configure_blueprint_routes
 from Ligare.web.config import Config, FlaskConfig
 from Ligare.web.testing.create_app import (
@@ -16,9 +12,7 @@ from Ligare.web.testing.create_app import (
     FlaskClientInjectorConfigurable,
 )
 from mock import MagicMock
-from pydantic import BaseModel
 from pytest_mock import MockerFixture
-from typing_extensions import override
 
 
 class TestCreateFlaskApp(CreateFlaskApp):
@@ -248,144 +242,3 @@ class TestCreateFlaskApp(CreateFlaskApp):
             match=r"^You must set \[flask\] in the application configuration\.",
         ):
             _ = next(flask_client_configurable(Config()))
-
-    def test__CreateFlaskApp__create_app__loads_config_from_toml(
-        self, basic_config: Config, mocker: MockerFixture
-    ):
-        _ = mocker.patch(
-            "Ligare.web.application.SSMParameters",
-            return_value=MagicMock(load_config=MagicMock(return_value=None)),
-        )
-        load_config_mock = mocker.patch(
-            "Ligare.web.application.load_config", return_value=basic_config
-        )
-
-        toml_filename = f"{TestCreateFlaskApp.test__CreateFlaskApp__create_app__loads_config_from_toml.__name__}-config.toml"
-        _ = App[Flask].create(config_filename=toml_filename)  # pyright: ignore[reportDeprecated]
-        assert load_config_mock.called
-        assert load_config_mock.call_args and load_config_mock.call_args[0]
-        assert load_config_mock.call_args[0][1] == toml_filename
-
-    def test__CreateFlaskApp__create_app__uses_custom_config_types(
-        self, mocker: MockerFixture
-    ):
-        _ = mocker.patch(
-            "Ligare.web.application.SSMParameters",
-            return_value=MagicMock(load_config=MagicMock(return_value=None)),
-        )
-        toml_filename = f"{TestCreateFlaskApp.test__CreateFlaskApp__create_app__uses_custom_config_types.__name__}-config.toml"
-        toml_load_result = {
-            "flask": {
-                "app_name": f"{TestCreateFlaskApp.test__CreateFlaskApp__create_app__uses_custom_config_types.__name__}-app_name"
-            },
-            "custom": {"foo": get_random_str(k=26)},
-        }
-
-        _ = mocker.patch("toml.load", return_value=toml_load_result)
-
-        class CustomConfig(BaseModel, AbstractConfig):
-            @override
-            def post_load(self) -> None:
-                return super().post_load()
-
-            foo: str = get_random_str(k=26)
-
-        app = App[Flask].create(  # pyright: ignore[reportDeprecated]
-            config_filename=toml_filename, application_configs=[CustomConfig]
-        )
-
-        assert (
-            app.app_injector.flask_injector.injector.get(CustomConfig).foo
-            == toml_load_result["custom"]["foo"]
-        )
-
-    @pytest.mark.parametrize(
-        "envvar_name,config_var_name,var_value",
-        [
-            ("FLASK_APP", "app_name", "foobar"),
-            ("FLASK_ENV", "env", "barfoo"),
-        ],
-    )
-    def test__CreateFlaskApp__create_app__updates_flask_config_from_envvars(
-        self,
-        envvar_name: str,
-        config_var_name: str,
-        var_value: str,
-        basic_config: Config,
-        mocker: MockerFixture,
-    ):
-        _ = mocker.patch(
-            "Ligare.web.application.SSMParameters",
-            return_value=MagicMock(load_config=MagicMock(return_value=None)),
-        )
-        object.__setattr__(basic_config.flask, config_var_name, var_value)
-
-        environ.update({envvar_name: var_value})
-        _ = mocker.patch(
-            "Ligare.web.application.load_config", return_value=basic_config
-        )
-        _ = App[Flask].create()  # pyright: ignore[reportDeprecated]
-
-        assert object.__getattribute__(basic_config.flask, config_var_name) == var_value
-
-    @pytest.mark.parametrize(
-        "envvar_name,config_var_name,var_value,should_fail",
-        [
-            ("FLASK_APP", None, "foobar", False),
-            ("FLASK_ENV", None, "barfoo", False),
-            (None, "app_name", "foobar", False),
-            (None, "app_name", "", True),
-            (None, "env", "barfoo", False),
-        ],
-    )
-    def test__CreateFlaskApp__create_app__requires_application_name(
-        self,
-        envvar_name: str | None,
-        config_var_name: str | None,
-        var_value: str,
-        should_fail: bool,
-        mocker: MockerFixture,
-    ):
-        _ = mocker.patch(
-            "Ligare.web.application.SSMParameters",
-            return_value=MagicMock(load_config=MagicMock(return_value=None)),
-        )
-        environ.update({"FLASK_APP": "", "FLASK_ENV": ""})
-
-        if envvar_name is not None:
-            environ.update({envvar_name: var_value})
-
-        toml_load_result = {}
-        if config_var_name is not None:
-            toml_load_result["flask"] = {config_var_name: var_value}
-
-        _ = mocker.patch("toml.load", return_value=toml_load_result)
-
-        if should_fail:
-            with pytest.raises(Exception):
-                _ = App[Flask].create()  # pyright: ignore[reportDeprecated]
-        else:
-            _ = App[Flask].create()  # pyright: ignore[reportDeprecated]
-
-    def test__CreateFlaskApp__create_app__configures_appropriate_app_type_based_on_config(
-        self, mocker: MockerFixture
-    ):
-        toml_filename = f"{TestCreateFlaskApp.test__CreateFlaskApp__create_app__configures_appropriate_app_type_based_on_config.__name__}-config.toml"
-        app_name = f"{TestCreateFlaskApp.test__CreateFlaskApp__create_app__configures_appropriate_app_type_based_on_config.__name__}-app_name"
-        _ = mocker.patch(
-            "Ligare.web.application.SSMParameters",
-            return_value=MagicMock(load_config=MagicMock(return_value=None)),
-        )
-        _ = mocker.patch("Ligare.web.application.register_error_handlers")
-        _ = mocker.patch("Ligare.web.application.register_api_request_handlers")
-        _ = mocker.patch("Ligare.web.application.register_api_response_handlers")
-        _ = mocker.patch("Ligare.web.application.configure_dependencies")
-
-        configure_method_mock = mocker.patch(
-            "Ligare.web.application.configure_blueprint_routes"
-        )
-        config = Config(flask=FlaskConfig(app_name=app_name))
-        _ = mocker.patch("Ligare.web.application.load_config", return_value=config)
-        _ = App[Flask].create(config_filename=toml_filename)  # pyright: ignore[reportDeprecated]
-
-        configure_method_mock.assert_called_once_with(config)

--- a/src/web/test/unit/application/test_create_openapi_app.py
+++ b/src/web/test/unit/application/test_create_openapi_app.py
@@ -50,7 +50,8 @@ class TestCreateOpenAPIApp(CreateOpenAPIApp):
 
         toml_filename = f"{TestCreateOpenAPIApp.test__CreateOpenAPIApp__create_app__loads_config_from_toml.__name__}-config.toml"
         application_builder = ApplicationBuilder(
-            Flask, import_name=basic_config.flask.app_name
+            Flask,
+            import_name=getattr(basic_config.flask, "app_name", None) or "test_app",
         ).use_configuration(
             lambda config_builder: config_builder.with_config_filename(toml_filename)
         )

--- a/src/web/test/unit/application/test_create_openapi_app.py
+++ b/src/web/test/unit/application/test_create_openapi_app.py
@@ -1,18 +1,10 @@
-from os import environ
-
 import pytest
-from connexion import FlaskApp
 from flask import Flask
-from Ligare.programming.config import AbstractConfig
-from Ligare.programming.str import get_random_str
-from Ligare.web.application import App  # pyright:ignore[reportDeprecated]
 from Ligare.web.application import ApplicationBuilder, configure_openapi
 from Ligare.web.config import Config, FlaskConfig, FlaskOpenApiConfig
 from Ligare.web.testing.create_app import CreateOpenAPIApp
 from mock import MagicMock
-from pydantic import BaseModel
 from pytest_mock import MockerFixture
-from typing_extensions import override
 
 
 class TestCreateOpenAPIApp(CreateOpenAPIApp):
@@ -49,142 +41,20 @@ class TestCreateOpenAPIApp(CreateOpenAPIApp):
         self, basic_config: Config, mocker: MockerFixture
     ):
         _ = mocker.patch(
-            "Ligare.web.application.SSMParameters",
+            "Ligare.AWS.ssm.SSMParameters",
             return_value=MagicMock(load_config=MagicMock(return_value=None)),
         )
         load_config_mock = mocker.patch(
-            "Ligare.web.application.load_config", return_value=basic_config
+            "Ligare.programming.application.load_config", return_value=basic_config
         )
 
         toml_filename = f"{TestCreateOpenAPIApp.test__CreateOpenAPIApp__create_app__loads_config_from_toml.__name__}-config.toml"
-        application_builder = ApplicationBuilder[Flask]().use_configuration(
+        application_builder = ApplicationBuilder(
+            Flask, import_name=basic_config.flask.app_name
+        ).use_configuration(
             lambda config_builder: config_builder.with_config_filename(toml_filename)
         )
         _ = application_builder.build()
         assert load_config_mock.called
         assert load_config_mock.call_args and load_config_mock.call_args[0]
         assert load_config_mock.call_args[0][1] == toml_filename
-
-    def test__CreateOpenAPIApp__create_app__uses_custom_config_types(
-        self, mocker: MockerFixture
-    ):
-        _ = mocker.patch(
-            "Ligare.web.application.SSMParameters",
-            return_value=MagicMock(load_config=MagicMock(return_value=None)),
-        )
-        toml_filename = f"{TestCreateOpenAPIApp.test__CreateOpenAPIApp__create_app__uses_custom_config_types.__name__}-config.toml"
-        toml_load_result = {
-            "flask": {
-                "app_name": f"{TestCreateOpenAPIApp.test__CreateOpenAPIApp__create_app__uses_custom_config_types.__name__}-app_name"
-            },
-            "custom": {"foo": get_random_str(k=26)},
-        }
-
-        _ = mocker.patch("toml.load", return_value=toml_load_result)
-
-        class CustomConfig(BaseModel, AbstractConfig):
-            @override
-            def post_load(self) -> None:
-                return super().post_load()
-
-            foo: str = get_random_str(k=26)
-
-        app = App[Flask].create(  # pyright:ignore[reportDeprecated]
-            config_filename=toml_filename, application_configs=[CustomConfig]
-        )
-
-        assert (
-            app.app_injector.flask_injector.injector.get(CustomConfig).foo
-            == toml_load_result["custom"]["foo"]
-        )
-
-    @pytest.mark.parametrize(
-        "envvar_name,config_var_name,var_value",
-        [
-            ("FLASK_APP", "app_name", "foobar"),
-            ("FLASK_ENV", "env", "barfoo"),
-        ],
-    )
-    def test__CreateOpenAPIApp__create_app__updates_flask_config_from_envvars(
-        self,
-        envvar_name: str,
-        config_var_name: str,
-        var_value: str,
-        basic_config: Config,
-        mocker: MockerFixture,
-    ):
-        _ = mocker.patch(
-            "Ligare.web.application.SSMParameters",
-            return_value=MagicMock(load_config=MagicMock(return_value=None)),
-        )
-        object.__setattr__(basic_config.flask, config_var_name, var_value)
-
-        environ.update({envvar_name: var_value})
-        _ = mocker.patch(
-            "Ligare.web.application.load_config", return_value=basic_config
-        )
-        _ = App[Flask].create()  # pyright:ignore[reportDeprecated]
-
-        assert object.__getattribute__(basic_config.flask, config_var_name) == var_value
-
-    @pytest.mark.parametrize(
-        "envvar_name,config_var_name,var_value,should_fail",
-        [
-            ("FLASK_APP", None, "foobar", False),
-            ("FLASK_ENV", None, "barfoo", False),
-            (None, "app_name", "foobar", False),
-            (None, "app_name", "", True),
-            (None, "env", "barfoo", False),
-        ],
-    )
-    def test__CreateOpenAPIApp__create_app__requires_application_name(
-        self,
-        envvar_name: str | None,
-        config_var_name: str | None,
-        var_value: str,
-        should_fail: bool,
-        mocker: MockerFixture,
-    ):
-        _ = mocker.patch(
-            "Ligare.web.application.SSMParameters",
-            return_value=MagicMock(load_config=MagicMock(return_value=None)),
-        )
-        environ.update({"FLASK_APP": "", "FLASK_ENV": ""})
-
-        if envvar_name is not None:
-            environ.update({envvar_name: var_value})
-
-        toml_load_result = {}
-        if config_var_name is not None:
-            toml_load_result["flask"] = {config_var_name: var_value}
-
-        _ = mocker.patch("toml.load", return_value=toml_load_result)
-
-        if should_fail:
-            with pytest.raises(Exception):
-                _ = App[Flask].create()  # pyright:ignore[reportDeprecated]
-        else:
-            _ = App[Flask].create()  # pyright:ignore[reportDeprecated]
-
-    def test__CreateOpenAPIApp__create_app__configures_appropriate_app_type_based_on_config(
-        self, mocker: MockerFixture
-    ):
-        toml_filename = f"{TestCreateOpenAPIApp.test__CreateOpenAPIApp__create_app__configures_appropriate_app_type_based_on_config.__name__}-config.toml"
-        app_name = f"{TestCreateOpenAPIApp.test__CreateOpenAPIApp__create_app__configures_appropriate_app_type_based_on_config.__name__}-app_name"
-        _ = mocker.patch(
-            "Ligare.web.application.SSMParameters",
-            return_value=MagicMock(load_config=MagicMock(return_value=None)),
-        )
-        _ = mocker.patch("Ligare.web.application.register_error_handlers")
-        _ = mocker.patch("Ligare.web.application.register_api_request_handlers")
-        _ = mocker.patch("Ligare.web.application.register_api_response_handlers")
-        _ = mocker.patch("Ligare.web.application.configure_dependencies")
-
-        configure_method_mock = mocker.patch("Ligare.web.application.configure_openapi")
-        config = Config(
-            flask=FlaskConfig(app_name=app_name, openapi=FlaskOpenApiConfig())
-        )
-        _ = mocker.patch("Ligare.web.application.load_config", return_value=config)
-        _ = App[FlaskApp].create(config_filename=toml_filename)  # pyright:ignore[reportDeprecated]
-
-        configure_method_mock.assert_called_once_with(config)

--- a/src/web/test/unit/test_config.py
+++ b/src/web/test/unit/test_config.py
@@ -1,9 +1,8 @@
 import pytest
-from flask import Flask
 from Ligare.programming.collections.dict import AnyDict
 from Ligare.programming.config import AbstractConfig, load_config
 from Ligare.programming.config.exceptions import ConfigBuilderStateError
-from Ligare.web.application import ApplicationBuilder, ApplicationConfigBuilder
+from Ligare.web.application import ApplicationConfigBuilder
 from Ligare.web.config import Config
 from Ligare.web.exception import BuilderBuildError, InvalidBuilderStateError
 from pydantic import BaseModel

--- a/src/web/test/unit/test_config.py
+++ b/src/web/test/unit/test_config.py
@@ -190,22 +190,3 @@ def test__ApplicationConfigBuilder__build__applies_config_overrides(
     assert hasattr(config, "logging")
     assert hasattr(getattr(config, "logging"), "log_level")
     assert getattr(getattr(config, "logging"), "log_level") == "INFO"
-
-
-# FIXME move to application tests
-def test__ApplicationBuilder__build__something(mocker: MockerFixture):
-    fake_config_dict = {"logging": {"log_level": "DEBUG"}, "flask": {"app_name": "app"}}
-    _ = mocker.patch("io.open")
-    _ = mocker.patch("toml.decoder.loads", return_value=fake_config_dict)
-
-    application_builder = ApplicationBuilder[Flask]().use_configuration(
-        lambda config_builder: config_builder.with_root_config_type(
-            Config
-        ).with_config_filename("foo.toml")
-    )
-
-    _ = (
-        application_builder.with_flask_app_name("overridden_app")
-        .with_flask_env("overridden_dev")
-        .build()
-    )


### PR DESCRIPTION
The `ApplicationBuilder` class currently exists in `Ligare.web`. This works fine for building web applications, but Ligare is meant to be neutral regarding the type of application a developer wants to build, especially CLI apps. Currently, using `ApplicationBuilder` means pulling in `Ligare.web` as a dependency. In order to avoid that, this change refactors `ApplicationBuilder` to instead be defined in `Ligare.programming`, removing it from `Ligare.web`. From there, `Ligare.web` extends the refactored `ApplicationBuilder` into its own builder for web applications.

This refactor also required adjustments to the Config system in `Ligare.programming` to allow more neutral handling of application configuration needs.

The `CreateFlaskApp` test class has been updated to support the refactors.

Some error messages have been updated to be less obtuse.

**Important**: the previously deprecated `create_app` and `App[T].create_app` methods have been removed. It was not possible to update these methods to support the refactor without muddying other code unnecessarily, so this PR removes them.