### PR TITLE
Resolve unquoted variable usage in workflow shell scripts.

### DIFF
--- a/.github/workflows/PyPI-scripts/extract-package-details-from-tag.sh
+++ b/.github/workflows/PyPI-scripts/extract-package-details-from-tag.sh
@@ -3,7 +3,7 @@ set -eo pipefail
 tag="${GITHUB_REF#refs/*/}"
 
 # This is the package name minus `Ligare.`.
-package_name=$(gawk 'match($0, /Ligare\.?([^-]+)?/, m) { print s m[1]}' <<<$tag)
+package_name="$(gawk 'match($0, /Ligare\.?([^-]+)?/, m) { print s m[1]}' <<<$tag)"
 # `all` is the root of the repository and includes all other packages
 if [ "$package_name" == "all" ]; then
     package_directory=.

--- a/.github/workflows/PyPI-scripts/extract-package-details-from-tag.sh
+++ b/.github/workflows/PyPI-scripts/extract-package-details-from-tag.sh
@@ -3,7 +3,7 @@ set -eo pipefail
 tag="${GITHUB_REF#refs/*/}"
 
 # This is the package name minus `Ligare.`.
-package_name="$(gawk 'match($0, /Ligare\.?([^-]+)?/, m) { print s m[1]}' <<<$tag)"
+package_name="$(gawk 'match($0, /Ligare\.?([^-]+)?/, m) { print s m[1]}' <<<"$tag")"
 # `all` is the root of the repository and includes all other packages
 if [ "$package_name" == "all" ]; then
     package_directory=.

--- a/publish_all.sh
+++ b/publish_all.sh
@@ -92,15 +92,15 @@ declare -a packages=( \
 
 initialize
 
-for package in ${packages[@]}; do
-    build $package
+for package in "${packages[@]}"; do
+    build "$package"
 done
 
 # default to testpypi
 [ -n "$1" ] && repository="$1" || repository="testpypi"
 
 tput init 2> /dev/null
-for package in ${packages[@]}; do
-    publish $package $repository
+for package in "${packages[@]}"; do
+    publish "$package" "$repository"
 done
 


### PR DESCRIPTION
Fixes errors from https://github.com/uclahs-cds/Ligare/actions/runs/12715075539/job/35446552822?pr=171

> Double quote array expansions to avoid re-splitting elements.

> Double quote to prevent globbing and word splitting. [SC2086]

