### PR TITLE
Fix breaking change in non-breaking version update from Alembic.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## Unreleased
 
 ---
+## `Ligare.all` [0.10.3] - 2025-06-09
+
+### Fixed
+- Fixed issue with breaking change from Alembic causing migration failures when creating Alembic config.
+
+### `Ligare.database` [0.5.1] - 2025-06-09
+
+* [Ligare.database v0.5.1](https://github.com/uclahs-cds/Ligare/blob/Ligare.database-v0.5.1/src/database/CHANGELOG.md#051---2025-06-09)
+
+---
+
 ## `Ligare.all` [0.10.2] - 2025-05-23
 
 ### Fixed
@@ -18,7 +29,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### `Ligare.programming` [0.7.1] - 2025-05-23
 
-* [Ligare.programming v0.7.1](https://github.com/uclahs-cds/Ligare/blob/Ligare.programming-v0.7.1/src/web/CHANGELOG.md#071---2025-05=23)
+* [Ligare.programming v0.7.1](https://github.com/uclahs-cds/Ligare/blob/Ligare.programming-v0.7.1/src/programming/CHANGELOG.md#071---2025-05-23)
 
 ---
 

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,1 +1,1 @@
-__version__: str = "0.10.2"
+__version__: str = "0.10.3"

--- a/src/database/CHANGELOG.md
+++ b/src/database/CHANGELOG.md
@@ -11,6 +11,10 @@ Review the `Ligare` [CHANGELOG.md](https://github.com/uclahs-cds/Ligare/blob/mai
 ---
 ## Unreleased
 
+## [0.5.1] - 2025-06-09
+### Fixed
+- Fixed issue with breaking change from Alembic causing migration failures when creating Alembic config.
+
 ## [0.5.0] - 2025-03-25
 ### Added
 - Added module-level documentation for all key components in `Ligare.database`, including engines, migrations, and schema.

--- a/src/database/Ligare/database/__init__.py
+++ b/src/database/Ligare/database/__init__.py
@@ -5,4 +5,4 @@ supporting both SQLite and PostgreSQL.
 For usage, see :ref:`ligare-database`.
 """
 
-__version__: str = "0.5.0"
+__version__: str = "0.5.1"

--- a/src/database/Ligare/database/migrations/alembic/ligare_alembic.py
+++ b/src/database/Ligare/database/migrations/alembic/ligare_alembic.py
@@ -68,7 +68,7 @@ class LigareAlembic:
         alembic_cli = CommandLine()
         parsed_args = alembic_cli.parser.parse_args(argv)
         self._log.debug(f"Parsed arguments: {parsed_args}")
-        config = Config(parsed_args.config)
+        config = Config(*parsed_args.config)
         self._log.debug(f"Instantiated config: {repr(config)}")
         return config
 


### PR DESCRIPTION
Alembic broke how configurations are created in version 1.16.0. https://github.com/sqlalchemy/alembic/issues/1660

This fixes Ligare's use of the class so it works again.

